### PR TITLE
Fix non-protected broadcasts sent from phone process.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -89,6 +89,10 @@
     <protected-broadcast android:name= "org.codeaurora.intent.action.ACTION_NETWORK_SPECIFIER_SET" />
     <protected-broadcast android:name= "org.codeaurora.intent.action.ACTION_DDS_SWITCH_DONE" />
     <protected-broadcast android:name= "org.codeaurora.VOIP_VOPS_SSAC_STATUS" />
+    <protected-broadcast android:name= "codeaurora.intent.action.ACTION_MANAGED_ROAMING_IND" />
+    <protected-broadcast android:name= "org.codeaurora.intent.action.PRIMARY_CARD_CHANGED_IN_SERVICE" />
+    <protected-broadcast android:name= "org.codeaurora.intent.action.ACTION_SET_PRIMARY_CARD_DONE" />
+    <protected-broadcast android:name= "codeaurora.intent.action.ACTION_LTE_CONFIGURE" />
 
     <uses-permission android:name="android.permission.BROADCAST_STICKY" />
     <uses-permission android:name="android.permission.CALL_PHONE" />


### PR DESCRIPTION
Intents broadcasted from system internals should be
protected inorder to avoid security holes. So fix is
to make the phone process intents broadcasted from
proprietary space to be protected.

Change-Id: Ie9cf2e5923b8a52e9b3ba91e9e9c3d649aae9fca
CRs-Fixed: 2128245

Signed-off-by: xyyx <xyyx@mail.ru>